### PR TITLE
Add Google auth and Windows run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,25 @@ into a minimal Express backend and a Vite powered React frontend.
 
 The frontend will run on <http://localhost:5173> and proxy API requests to the
 backend on port `3001`.
+
+### Google Authentication
+
+The backend uses Google OAuth for user authentication. Create a `.env` file in
+the `backend` directory with the following variables:
+
+```bash
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+```
+
+You can obtain these from the Google Developer Console.
+
+### Windows Convenience Script
+
+For Windows users running Git Bash or WSL, a helper script `run_windows.sh` is
+provided in the project root. It installs dependencies and starts both the
+backend and frontend:
+
+```bash
+./run_windows.sh
+```

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,10 @@
   "dependencies": {
     "express": "^4.18.2",
     "cors": "^2.8.5",
-    "sqlite3": "^5.1.2"
+    "sqlite3": "^5.1.2",
+    "express-session": "^1.17.3",
+    "passport": "^0.6.0",
+    "passport-google-oauth20": "^2.0.0",
+    "dotenv": "^16.0.0"
   }
 }

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,10 +1,18 @@
 const express = require('express');
+const passport = require('passport');
 const router = express.Router();
 
-// POST /auth/login
-router.post('/login', (req, res) => {
-  // TODO: implement login logic
-  res.send({ token: 'fake-jwt-token' });
+// Redirect user to Google for authentication
+router.get('/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
+
+// Google OAuth2 callback
+router.get('/google/callback', passport.authenticate('google', { failureRedirect: '/' }), (req, res) => {
+  const user = {
+    id: req.user.id,
+    displayName: req.user.displayName,
+    emails: req.user.emails,
+  };
+  res.json(user);
 });
 
 module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,12 +1,39 @@
+require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
+const session = require('express-session');
+const passport = require('passport');
+const GoogleStrategy = require('passport-google-oauth20').Strategy;
 const authRoutes = require('./routes/auth');
 const tournamentRoutes = require('./routes/tournaments');
 const app = express();
 const PORT = process.env.PORT || 3001;
 
+passport.use(new GoogleStrategy({
+  clientID: process.env.GOOGLE_CLIENT_ID,
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+  callbackURL: '/auth/google/callback'
+}, (accessToken, refreshToken, profile, done) => {
+  return done(null, profile);
+}));
+
+passport.serializeUser((user, done) => {
+  done(null, user);
+});
+
+passport.deserializeUser((user, done) => {
+  done(null, user);
+});
+
 app.use(cors());
 app.use(express.json());
+app.use(session({
+  secret: 'cricketify-secret',
+  resave: false,
+  saveUninitialized: false
+}));
+app.use(passport.initialize());
+app.use(passport.session());
 
 // Basic routes
 app.get('/', (req, res) => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ export default function App() {
   return (
     <div>
       <h1>Welcome to Cricketify</h1>
+      <a href="http://localhost:3001/auth/google">Login with Google</a>
     </div>
   );
 }

--- a/run_windows.sh
+++ b/run_windows.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Convenience script for Windows users using Git Bash or WSL
+
+# Install backend dependencies
+pushd backend >/dev/null
+npm install
+npm start &
+BACK_PID=$!
+popd >/dev/null
+
+# Install frontend dependencies and start dev server
+pushd frontend >/dev/null
+npm install
+npm run start &
+FRONT_PID=$!
+popd >/dev/null
+
+# Wait for servers
+wait $BACK_PID $FRONT_PID


### PR DESCRIPTION
## Summary
- set up Google OAuth in the backend
- add login link in the frontend
- document authentication and helper script in README
- provide `run_windows.sh` helper for Windows environments

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a0bc1d70483258d2c0c0b472f3149