### PR TITLE
Implement initial OAuth and basic routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,21 @@ into a minimal Express backend and a Vite powered React frontend.
 The frontend will run on <http://localhost:5173> and proxy API requests to the
 backend on port `3001`.
 
-### Google Authentication
+### SSO Authentication
 
-The backend uses Google OAuth for user authentication. Create a `.env` file in
-the `backend` directory with the following variables:
+The backend relies entirely on Google and Facebook OAuth for authentication and
+initial user profile creation. Create a `.env` file in the `backend` directory
+with the following variables:
 
 ```bash
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
+FACEBOOK_CLIENT_ID=your-facebook-client-id
+FACEBOOK_CLIENT_SECRET=your-facebook-client-secret
 ```
 
-You can obtain these from the Google Developer Console.
+You can obtain these from the Google Developer Console and Facebook Developer
+portal.
 
 ### Windows Convenience Script
 

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+const DB_PATH = path.join(__dirname, '..', 'db', 'cricketify.sqlite');
+const SCHEMA_PATH = path.join(__dirname, '..', 'db', 'schema.sql');
+
+const db = new sqlite3.Database(DB_PATH);
+
+// Initialize database if tables do not exist
+function init() {
+  const schema = fs.readFileSync(SCHEMA_PATH, 'utf8');
+  db.exec(schema);
+}
+
+module.exports = {
+  db,
+  init
+};
+

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "express-session": "^1.17.3",
     "passport": "^0.6.0",
     "passport-google-oauth20": "^2.0.0",
+    "passport-facebook": "^3.0.0",
     "dotenv": "^16.0.0"
   }
 }

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const passport = require('passport');
+const { db } = require('../db');
 const router = express.Router();
 
 // Redirect user to Google for authentication
@@ -7,12 +8,39 @@ router.get('/google', passport.authenticate('google', { scope: ['profile', 'emai
 
 // Google OAuth2 callback
 router.get('/google/callback', passport.authenticate('google', { failureRedirect: '/' }), (req, res) => {
-  const user = {
-    id: req.user.id,
-    displayName: req.user.displayName,
-    emails: req.user.emails,
-  };
-  res.json(user);
+  const profile = req.user;
+  const email = profile.emails && profile.emails[0] ? profile.emails[0].value : '';
+  db.run(
+    `INSERT OR IGNORE INTO users (name, email, role, profile_picture, provider, provider_id) VALUES (?, ?, 'Player', ?, 'google', ?)`,
+    [profile.displayName, email, profile.photos && profile.photos[0] ? profile.photos[0].value : null, profile.id],
+    function(err) {
+      if (err) return res.status(500).send({ error: err.message });
+      db.get('SELECT * FROM users WHERE provider = ? AND provider_id = ?', ['google', profile.id], (err, row) => {
+        if (err) return res.status(500).send({ error: err.message });
+        res.json(row);
+      });
+    }
+  );
+});
+
+// Redirect user to Facebook for authentication
+router.get('/facebook', passport.authenticate('facebook', { scope: ['email'] }));
+
+// Facebook OAuth callback
+router.get('/facebook/callback', passport.authenticate('facebook', { failureRedirect: '/' }), (req, res) => {
+  const profile = req.user;
+  const email = profile.emails && profile.emails[0] ? profile.emails[0].value : '';
+  db.run(
+    `INSERT OR IGNORE INTO users (name, email, role, profile_picture, provider, provider_id) VALUES (?, ?, 'Player', ?, 'facebook', ?)`,
+    [profile.displayName, email, profile.photos && profile.photos[0] ? profile.photos[0].value : null, profile.id],
+    function(err) {
+      if (err) return res.status(500).send({ error: err.message });
+      db.get('SELECT * FROM users WHERE provider = ? AND provider_id = ?', ['facebook', profile.id], (err, row) => {
+        if (err) return res.status(500).send({ error: err.message });
+        res.json(row);
+      });
+    }
+  );
 });
 
 module.exports = router;

--- a/backend/routes/matches.js
+++ b/backend/routes/matches.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const { db } = require('../db');
+
+const router = express.Router();
+
+// GET /matches
+router.get('/', (req, res) => {
+  db.all('SELECT * FROM matches', [], (err, rows) => {
+    if (err) return res.status(500).send({ error: err.message });
+    res.send(rows);
+  });
+});
+
+// POST /matches
+router.post('/', (req, res) => {
+  const { season_id, team1_id, team2_id, date, location, status } = req.body;
+  const stmt = db.prepare('INSERT INTO matches (season_id, team1_id, team2_id, date, location, status) VALUES (?, ?, ?, ?, ?, ?)');
+  stmt.run(season_id, team1_id, team2_id, date, location, status, function(err) {
+    if (err) return res.status(500).send({ error: err.message });
+    res.status(201).send({ id: this.lastID });
+  });
+});
+
+module.exports = router;
+

--- a/backend/routes/tournaments.js
+++ b/backend/routes/tournaments.js
@@ -1,16 +1,24 @@
 const express = require('express');
 const router = express.Router();
 
+const { db } = require('../db');
+
 // GET /tournaments
 router.get('/', (req, res) => {
-  // TODO: fetch tournaments from DB
-  res.send([]);
+  db.all('SELECT * FROM tournaments', [], (err, rows) => {
+    if (err) return res.status(500).send({ error: err.message });
+    res.send(rows);
+  });
 });
 
 // POST /tournament
 router.post('/', (req, res) => {
-  // TODO: create tournament
-  res.status(201).send({ id: 1 });
+  const { name, slug, organizer_id, format, overs_per_match, max_players, year } = req.body;
+  const stmt = db.prepare('INSERT INTO tournaments (name, slug, organizer_id, format, overs_per_match, max_players, year) VALUES (?, ?, ?, ?, ?, ?, ?)');
+  stmt.run(name, slug, organizer_id, format, overs_per_match, max_players, year, function(err) {
+    if (err) return res.status(500).send({ error: err.message });
+    res.status(201).send({ id: this.lastID });
+  });
 });
 
 module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,15 +4,30 @@ const cors = require('cors');
 const session = require('express-session');
 const passport = require('passport');
 const GoogleStrategy = require('passport-google-oauth20').Strategy;
+const FacebookStrategy = require('passport-facebook').Strategy;
 const authRoutes = require('./routes/auth');
 const tournamentRoutes = require('./routes/tournaments');
+const matchesRoutes = require('./routes/matches');
+const { init } = require('./db');
 const app = express();
 const PORT = process.env.PORT || 3001;
+
+// initialize sqlite database
+init();
 
 passport.use(new GoogleStrategy({
   clientID: process.env.GOOGLE_CLIENT_ID,
   clientSecret: process.env.GOOGLE_CLIENT_SECRET,
   callbackURL: '/auth/google/callback'
+}, (accessToken, refreshToken, profile, done) => {
+  return done(null, profile);
+}));
+
+passport.use(new FacebookStrategy({
+  clientID: process.env.FACEBOOK_CLIENT_ID,
+  clientSecret: process.env.FACEBOOK_CLIENT_SECRET,
+  callbackURL: '/auth/facebook/callback',
+  profileFields: ['id', 'displayName', 'photos', 'email']
 }, (accessToken, refreshToken, profile, done) => {
   return done(null, profile);
 }));
@@ -43,7 +58,7 @@ app.get('/', (req, res) => {
 app.use('/auth', authRoutes);
 app.use('/tournaments', tournamentRoutes);
 
-// TODO: implement matches routes
+app.use('/matches', matchesRoutes);
 
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -4,9 +4,11 @@ CREATE TABLE users (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   name TEXT NOT NULL,
   email TEXT UNIQUE NOT NULL,
-  password_hash TEXT NOT NULL,
+  password_hash TEXT,
   role TEXT NOT NULL,
-  profile_picture TEXT
+  profile_picture TEXT,
+  provider TEXT,
+  provider_id TEXT
 );
 
 CREATE TABLE tournaments (

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,34 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+
+function Tournaments() {
+  const [tournaments, setTournaments] = useState([]);
+
+  useEffect(() => {
+    fetch('http://localhost:3001/tournaments')
+      .then(res => res.json())
+      .then(setTournaments)
+      .catch(() => setTournaments([]));
+  }, []);
+
+  return (
+    <ul>
+      {tournaments.map(t => (
+        <li key={t.id}>{t.name}</li>
+      ))}
+    </ul>
+  );
+}
 
 export default function App() {
   return (
     <div>
       <h1>Welcome to Cricketify</h1>
-      <a href="http://localhost:3001/auth/google">Login with Google</a>
+      <p>
+        <a href="http://localhost:3001/auth/google">Login with Google</a>
+        {' | '}
+        <a href="http://localhost:3001/auth/facebook">Login with Facebook</a>
+      </p>
+      <Tournaments />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add facebook auth and improve google auth with persistence
- implement tournament and match routes with sqlite
- initialize database on startup
- add simple tournament list on frontend
- update README with SSO instructions

## Testing
- `npm start` *(fails: Cannot find module 'dotenv')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cors)*
- `npm start` in frontend *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0cd10a348325951dae66db449a77